### PR TITLE
refactor: remove the output stream :(

### DIFF
--- a/LLM/google.go
+++ b/LLM/google.go
@@ -2,6 +2,7 @@ package LLM
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/google/generative-ai-go/genai"
 	"google.golang.org/api/iterator"
@@ -22,7 +23,6 @@ func New_Google(max_tokens int) *Google {
 func (cs *Google) Simple_Chat(args Client_Args) error {
 	client := cs.Client
 	ctx := cs.Context
-	out := args.Out
 
 	model := client.GenerativeModel("gemini-1.5-pro")
 	model.SetMaxOutputTokens(int32(args.Max_Tokens))
@@ -31,8 +31,8 @@ func (cs *Google) Simple_Chat(args Client_Args) error {
 		return err
 	}
 
-	out.Printf("%s", resp.Candidates[0].Content.Parts[0])
-	out.Printf("\n<------>\n")
+	fmt.Printf("%s", resp.Candidates[0].Content.Parts[0])
+	fmt.Printf("\n<------>\n")
 
 	return nil
 }
@@ -42,16 +42,15 @@ func (cs *Google) Simple_Chat(args Client_Args) error {
 // model.SetTopK(40)
 // model.SystemInstruction = genai.NewUserContent(genai.Text("You are Yoda from Star Wars."))
 // model.ResponseMIMEType = "application/json"
-func (cs *Google) Chat(args Client_Args) error {
+func (cs *Google) Chat(args Client_Args) (string, error) {
 	client := cs.Client
 	ctx := cs.Context
-	out := args.Out
 
 	model := client.GenerativeModel("gemini-1.5-pro")
 	model.SetTemperature(0.3)
 	model.SetMaxOutputTokens(int32(args.Max_Tokens))
 
-	out.Printf("Assistant: ")
+	var resp_str string
 	iter := model.GenerateContentStream(ctx, genai.Text(args.Prompt))
 	for {
 		resp, err := iter.Next()
@@ -59,10 +58,12 @@ func (cs *Google) Chat(args Client_Args) error {
 			break
 		}
 		if err != nil {
-			return err
+			return "", err
 		}
-		out.Printf("%s", resp.Candidates[0].Content.Parts[0])
+
+		resp_str += fmt.Sprintf("%s", resp.Candidates[0].Content.Parts[0])
+		fmt.Printf("%s", resp.Candidates[0].Content.Parts[0])
 	}
 
-	return nil
+	return resp_str, nil
 }

--- a/LLM/openai.go
+++ b/LLM/openai.go
@@ -15,9 +15,8 @@ func New_OpenAI(max_tokens int) *OpenAI {
 	return &OpenAI{API_Key: api_key, Tokens: max_tokens, Client: client}
 }
 
-func (cs *OpenAI) Chat(args Client_Args) error {
+func (cs *OpenAI) Chat(args Client_Args) (string, error) {
 	client := cs.Client
-	out := args.Out
 
 	// AssistantMessage takes a single string but args.Context is an array
 	msg_context := ""
@@ -46,19 +45,20 @@ func (cs *OpenAI) Chat(args Client_Args) error {
 	// across the entire screen.
 	// TODO: make the `log` an aggregate of streams, as in the TODO for the
 	// main app; so that it's not just going to stdout by default
-	out.Printf("Assistant: ")
+	var resp string
 	for stream.Next() {
 		evt := stream.Current()
 		if len(evt.Choices) > 0 {
 			data := evt.Choices[0].Delta.Content
-			out.Printf(data)
+			resp += data
+			fmt.Printf(data)
 		}
 	}
 
 	if stream.Err() != nil {
 		fmt.Printf("Error: %s\n", stream.Err())
-		return stream.Err()
+		return "", stream.Err()
 	}
 
-	return nil
+	return resp, nil
 }

--- a/LLM/types.go
+++ b/LLM/types.go
@@ -10,8 +10,13 @@ import (
 
 // These fields need to have capital lettesr to be exported (ugh)
 
+type LLM_Conversations struct {
+	Role    string `yaml:"role"`
+	Content string `yaml:"content"`
+}
+
 type Client interface {
-	Chat(args Client_Args) error
+	Chat(args Client_Args) (string, error)
 }
 
 type Anthropic struct {
@@ -37,5 +42,5 @@ type Client_Args struct {
 	Prompt     string
 	Context    []string
 	Max_Tokens int
-	Out        *Output_Stream
+	Log        *string
 }

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/liushuangls/go-anthropic/v2 v2.10.0
 	github.com/openai/openai-go v0.1.0-alpha.30
 	google.golang.org/api v0.204.0
+	gopkg.in/yaml.v2 v2.4.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -172,7 +172,10 @@ google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpAD
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 google.golang.org/protobuf v1.35.1 h1:m3LfL6/Ca+fqnjnlqQXNpFPABW1UD7mjh8KO2mKFytA=
 google.golang.org/protobuf v1.35.1/go.mod h1:9fA7Ob0pmnwhb644+1+CVWFRbNajQ6iRojtC/QF5bRE=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/main.go
+++ b/main.go
@@ -14,6 +14,10 @@ import (
 
 func chat_with_llm(model string, args LLM.Client_Args) {
 	var client LLM.Client
+	log := args.Log
+
+	fmt.Printf("User: " + args.Prompt + "\n\n")
+	fmt.Printf("Assistant: ")
 
 	switch model {
 	case "chatgpt":
@@ -26,36 +30,42 @@ func chat_with_llm(model string, args LLM.Client_Args) {
 		fmt.Println("Unknown model: ", model)
 	}
 
-	err := client.Chat(args)
+	resp, err := client.Chat(args)
 	if err != nil {
 		fmt.Println("Error: ", err)
 		os.Exit(1)
 	}
+
+	LLM.Log_Chat(log, "user", args.Prompt)
+	LLM.Log_Chat(log, "assistant ("+model+")", resp)
 }
 
 func main() {
 	HOME := os.Getenv("HOME")
 
 	model := flag.String("model", "claude", "Which LLM to use (claude|chatgpt|gemini)")
-	log_fn := flag.String("log", HOME+"/.config/ask-ai/ask-ai.chat.log", "Chat log file")
+	log_fn := flag.String("log", HOME+"/.config/ask-ai/ask-ai.chat.yml", "Chat log file")
 	context := flag.Int("context", 0, "Use n previous messages for context")
 	max_tokens := flag.Int("max-tokens", 4096, "Maximum tokens to generate")
 
 	flag.Parse()
 
-	log, err := os.OpenFile(*log_fn, os.O_APPEND|os.O_RDWR|os.O_CREATE, 0644)
-	if err != nil {
-		fmt.Println("Error opening/creating chat log file: ", err)
-		fmt.Println("CHAT WILL NOT BE SAVED (but we're forging on)")
+	if _, err := os.Stat(*log_fn); err != nil {
+		if os.IsNotExist(err) {
+			if err := os.WriteFile(*log_fn, []byte(""), 0644); err != nil {
+				fmt.Println("Error opening/creating chat log file: ", err)
+			}
+		} else {
+			fmt.Println("error checking file existence: %w", err)
+		}
 	}
-	defer log.Close()
 
-	var ostr *LLM.Output_Stream
-	ostr = LLM.New_Output_Stream()
-	ostr.Add_Stream("stdout", os.Stdout)
-	if log != nil {
-		ostr.Add_Stream("log", log)
-	}
+	// log, err := os.OpenFile(*log_fn, os.O_APPEND|os.O_RDWR|os.O_CREATE, 0644)
+	// if err != nil {
+	// 	fmt.Println("Error opening/creating chat log file: ", err)
+	// 	fmt.Println("CHAT WILL NOT BE SAVED (but we're forging on)")
+	// }
+	// defer log.Close()
 
 	var prompt_context []string
 	if context != nil {
@@ -72,6 +82,7 @@ func main() {
 	}
 
 	var prompt string
+	var err error
 	if flag.NArg() > 0 {
 		prompt = flag.Arg(0)
 	} else {
@@ -85,16 +96,13 @@ func main() {
 		}
 		fmt.Println()
 	}
-	ostr.Printf("User: " + prompt + "\n\n")
 
 	client_args := LLM.Client_Args{
 		Prompt:     prompt,
 		Context:    prompt_context,
 		Max_Tokens: *max_tokens,
-		Out:        ostr,
+		Log:        log_fn,
 	}
 
 	chat_with_llm(*model, client_args)
-
-	ostr.Printf("\n\n<model - %s>\n<------>\n", *model)
 }


### PR DESCRIPTION
This is because Anthropic and maybe others need the structured output for context, and it's easier to do (sort of) by saving structured data. Plus I think saving structured data will be better in the long run.

I really liked the idea of having teh Output_Stream that would write to multiple, registered outputs with a single call but I have to let it go.
