### PR TITLE
fix: don't warn if config file is not found

### DIFF
--- a/cmd/ask-ai.go
+++ b/cmd/ask-ai.go
@@ -88,9 +88,7 @@ func main() {
 	}
 
 	if err = viper.ReadInConfig(); err != nil {
-		if _, ok := err.(viper.ConfigFileNotFoundError); ok {
-			fmt.Printf("No configuration file found: %s\n", *cfg_file)
-		} else {
+		if _, ok := err.(viper.ConfigFileNotFoundError); !ok {
 			panic(fmt.Errorf("fatal error config file: %w", err))
 		}
 	}


### PR DESCRIPTION
Panic though if the file is there but not readable. That may change in the future.
