### PR TITLE
fix: trying to access an out of bounds index

### DIFF
--- a/cmd/ask-ai.go
+++ b/cmd/ask-ai.go
@@ -57,8 +57,6 @@ func main() {
 		fmt.Printf("%s> ", opts.Model)
 		reader := bufio.NewReader(os.Stdin)
 		prompt, err = reader.ReadString('\n')
-		// Now promptly remove the newline we just captured
-		prompt = prompt[:len(prompt)-1]
 		if err != nil {
 			if err.Error() == "EOF" {
 				fmt.Println()
@@ -67,6 +65,8 @@ func main() {
 			fmt.Println("Error reading prompt: ", err)
 			os.Exit(1)
 		}
+		// Now promptly remove the newline we just captured
+		prompt = prompt[:len(prompt)-1]
 		fmt.Println()
 	}
 


### PR DESCRIPTION
This happened when CTRL-D (EOF) was typed and there was nothing in the prompt variable.
