### PR TITLE
feat: add schema handling ability to db infra

### DIFF
--- a/cmd/ask-ai.go
+++ b/cmd/ask-ai.go
@@ -52,7 +52,7 @@ func main() {
 	}
 
 	// If DB exists, it just opens it; otherwise, it creates it first
-	db, err := database.NewDB(opts.DBFileName, opts.DBTable)
+	db, err := database.InitializeDB(opts.DBFileName, opts.DBTable)
 	if err != nil {
 		fmt.Println("Error opening database: ", err)
 		os.Exit(1)
@@ -145,7 +145,7 @@ func chatWithLLM(args LLM.ClientArgs, continueChat bool, db *database.ChatDB) {
 	// timestamp when the function is executed.
 
 	LLM.LogChat(log, "Assistant", resp.Text, model, continueChat, resp.InputTokens, resp.OutputTokens)
-	err = db.InsertConversation(*args.Prompt, resp.Text, model, *args.Temperature)
+	err = db.InsertConversation(*args.Prompt, resp.Text, model, *args.Temperature, resp.InputTokens, resp.OutputTokens)
 	if err != nil {
 		fmt.Println("error inserting conversation into database: ", err)
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -25,7 +25,8 @@ type Options struct {
 	Temperature   float32
 }
 
-const version = "0.4.0"
+const Version = "0.4.0"
+const SchemaVersion = 2
 
 var (
 	commit = "Unknown"
@@ -108,11 +109,11 @@ func Initialize() (*Options, error) {
 
 func handleVersionFlags() bool {
 	if viper.GetBool("version") {
-		fmt.Println("ask-ai version:", version)
+		fmt.Println("ask-ai version:", Version)
 		return true
 	}
 	if viper.GetBool("full-version") {
-		fmt.Printf("Version: %s\nCommit:  %s\nDate:    %s\n", version, commit, date)
+		fmt.Printf("Version: %s\nCommit:  %s\nDate:    %s\n", Version, commit, date)
 		return true
 	}
 	return false

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -200,12 +200,12 @@ func HandleVersionFlags(t *testing.T) {
 		{
 			name:           "version flag",
 			args:           []string{"--version"},
-			expectedOutput: "ask-ai version: " + version + "\n",
+			expectedOutput: "ask-ai version: " + Version + "\n",
 		},
 		{
 			name: "full version flag",
 			args: []string{"--full-version"},
-			expectedOutput: "Version: " + version + "\n" +
+			expectedOutput: "Version: " + Version + "\n" +
 				"Commit:  " + commit + "\n" +
 				"Date:    " + date + "\n",
 		},

--- a/pkg/database/db.go
+++ b/pkg/database/db.go
@@ -1,0 +1,117 @@
+package database
+
+// ALTER TABLE conversations
+// ADD COLUMN new_column1 TEXT;
+// ALTER TABLE conversations
+// ADD COLUMN new_column2 INTEGER;
+//
+// PRAGMA user_version = 2;
+
+import (
+	"database/sql"
+	"strconv"
+
+	"github.com/duluk/ask-ai/pkg/config"
+)
+
+func DBSchema(dbTable string) string {
+	return `
+	CREATE TABLE IF NOT EXISTS ` + dbTable + ` (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		timestamp DATETIME DEFAULT CURRENT_TIMESTAMP,
+		prompt TEXT NOT NULL,
+		response TEXT NOT NULL,
+		model_name TEXT NOT NULL,
+		temperature REAL NOT NULL,
+		input_tokens INTEGER,
+		output_tokens INTEGER
+	);
+	`
+}
+
+func SchemaQueryV1(dbTable string) string {
+	return `
+	CREATE TABLE IF NOT EXISTS ` + dbTable + ` (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		timestamp DATETIME DEFAULT CURRENT_TIMESTAMP,
+		prompt TEXT NOT NULL,
+		response TEXT NOT NULL,
+		model_name TEXT NOT NULL,
+		temperature REAL NOT NULL
+	);
+
+	PRAGMA user_version = 1;
+	`
+}
+
+func SchemaQueryV2(dbTable string) string {
+	return `
+	ALTER TABLE ` + dbTable + ` ADD COLUMN input_tokens INTEGER;
+	ALTER TABLE ` + dbTable + ` ADD COLUMN output_tokens INTEGER;
+
+	PRAGMA user_version = 2;
+	`
+}
+
+func getSchemaSQL(schemaVersion int, dbTable string) string {
+	switch schemaVersion {
+	case 1:
+		return SchemaQueryV1(dbTable)
+	case 2:
+		return SchemaQueryV2(dbTable)
+	default:
+		return ""
+	}
+}
+
+func applySchema(db *sql.DB, dbTable string, schemaVersion int) error {
+	tx, err := db.Begin()
+	if err != nil {
+		return err
+	}
+
+	_, err = tx.Exec(getSchemaSQL(schemaVersion, dbTable))
+
+	if err != nil {
+		tx.Rollback()
+		return err
+	}
+
+	err = tx.Commit()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func setSchemaVersion(db *sql.DB, schemaVersion int) error {
+	verStr := strconv.Itoa(schemaVersion)
+	_, err := db.Exec(`PRAGMA user_version = ` + verStr)
+	return err
+}
+
+func InitializeDB(dbPath string, dbTable string) (*ChatDB, error) {
+	// DB created only if it doesn't exist
+	chatDB, err := NewDB(dbPath, dbTable)
+
+	var currentVersion int
+	err = chatDB.db.QueryRow("PRAGMA user_version").Scan(&currentVersion)
+	if currentVersion == 0 {
+		// This should mean it's the first time we've created this database,
+		// which means it should be using the latest schema, which should mean
+		// the latest schema version. So just set that.
+		setSchemaVersion(chatDB.db, config.SchemaVersion)
+	} else if currentVersion < config.SchemaVersion {
+		// If the current schema exists but is less than the latest schema,
+		// apply each schema that was missed.
+		for i := currentVersion + 1; i <= config.SchemaVersion; i++ {
+			err = applySchema(chatDB.db, dbTable, i)
+			if err != nil {
+				return chatDB, err
+			}
+		}
+	}
+
+	return chatDB, err
+}

--- a/pkg/database/sqlite3_test.go
+++ b/pkg/database/sqlite3_test.go
@@ -30,20 +30,6 @@ func TestNewDB(t *testing.T) {
 	db.Close()
 }
 
-func TestCreateTable(t *testing.T) {
-	// Create a new DB and assert that it's not nil
-	db, err := NewDB(dbPath, dbTable)
-	assert.Nil(t, err)
-	assert.NotNil(t, db)
-
-	// Call createTable on the existing DB to assert it doesn't error
-	err = createTable(db.db, dbTable)
-	assert.Nil(t, err)
-
-	// Close the DB to clean up
-	db.Close()
-}
-
 func TestInsertConversation(t *testing.T) {
 	// Create a new DB and assert that it's not nil
 	db, err := NewDB(dbPath, dbTable)
@@ -51,7 +37,7 @@ func TestInsertConversation(t *testing.T) {
 	assert.NotNil(t, db)
 
 	// Insert a conversation with valid data and assert there are no errors
-	err = db.InsertConversation("prompt", "response", "model_name", 0.5)
+	err = db.InsertConversation("prompt", "response", "model_name", 0.5, 10, 20)
 	assert.Nil(t, err)
 
 	// Close the DB to clean up


### PR DESCRIPTION
Basically, can now udpate the database by adding the schema to the db.go file, updating the schema version and then just running the app. It will figure out how many schema versions have been missed and apply them, so going back to a really old DB should still work.
