### PR TITLE
feat: use last used model when continuing chat

### DIFF
--- a/cmd/ask-ai/main.go
+++ b/cmd/ask-ai/main.go
@@ -51,6 +51,7 @@ func main() {
 	}
 	defer db.Close()
 
+	model := opts.Model
 	/* CONTEXT? LOAD IT */
 	var promptContext []LLM.LLMConversations
 	if opts.ConversationID != 0 {
@@ -59,11 +60,18 @@ func main() {
 		// promptContext, err = LLM.LoadConversationFromLog(log_fd,
 		// opts.ConversationID)
 		promptContext, err = db.LoadConversationFromDB(opts.ConversationID)
+		if !pflag.CommandLine.Changed("model") {
+			// model, _ = db.GetModel(opts.ConversationID)
+			model = promptContext[len(promptContext)-1].Model
+		}
 		if err != nil {
 			fmt.Println("Error loading conversation from log: ", err)
 		}
 	} else if opts.ContinueChat {
 		promptContext, err = LLM.ContinueConversation(log_fd)
+		if !pflag.CommandLine.Changed("model") {
+			model = promptContext[len(promptContext)-1].Model
+		}
 		if err != nil {
 			fmt.Println("Error reading log for continuing chat: ", err)
 		}
@@ -75,7 +83,7 @@ func main() {
 	}
 
 	clientArgs := LLM.ClientArgs{
-		Model:        &opts.Model,
+		Model:        &model,
 		SystemPrompt: &opts.SystemPrompt,
 		Context:      promptContext,
 		MaxTokens:    &opts.MaxTokens,

--- a/pkg/database/sqlite3.go
+++ b/pkg/database/sqlite3.go
@@ -151,6 +151,26 @@ func (sqlDB *ChatDB) SearchForConversation(keyword string) ([]int, error) {
 	return responses, nil
 }
 
+func (sqlDB *ChatDB) GetModel(convID int) (string, error) {
+	rows, err := sqlDB.db.Query(`
+		SELECT model_name FROM `+sqlDB.dbTable+` WHERE conv_id = ?;
+	`, convID)
+	if err != nil {
+		return "", fmt.Errorf("%v", err)
+	}
+	defer rows.Close()
+
+	var model string
+	for rows.Next() {
+		err := rows.Scan(&model)
+		if err != nil {
+			return "", fmt.Errorf("%v", err)
+		}
+	}
+
+	return model, nil
+}
+
 func (sqlDB *ChatDB) ShowConversation(convID int) {
 	rows, err := sqlDB.db.Query(`
 		SELECT prompt, response, model_name, temperature, input_tokens, output_tokens, conv_id


### PR DESCRIPTION
Unless a model is specified as a CLI argument; in that case, use it instead.

Note that if multiple models are used in a conversation, the last one will be used if one is not specified.
